### PR TITLE
[Discussion] [Live Share] Restricting language services to local files

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,6 +33,11 @@ class HLSLFormatingProvider implements vscode.DocumentFormattingEditProvider, vs
 
 }
 
+const documentSelector = [
+    { language: 'hlsl', scheme: 'file' },
+    { language: 'hlsl', scheme: 'untitled' },
+];
+
 export async function activate(context: vscode.ExtensionContext) {
 
     console.log('vscode-shader extension started');
@@ -48,24 +53,27 @@ export async function activate(context: vscode.ExtensionContext) {
     }
 
     // add providers
-    context.subscriptions.push(vscode.languages.registerHoverProvider('hlsl', new HLSLHoverProvider()));
-    context.subscriptions.push(vscode.languages.registerCompletionItemProvider('hlsl', new HLSLCompletionItemProvider(), '.'));
-    context.subscriptions.push(vscode.languages.registerSignatureHelpProvider('hlsl', new HLSLSignatureHelpProvider(), '(', ','));
-    context.subscriptions.push(vscode.languages.registerReferenceProvider('hlsl', new HLSLReferenceProvider()));
+    context.subscriptions.push(vscode.languages.registerHoverProvider(documentSelector, new HLSLHoverProvider()));
+    context.subscriptions.push(vscode.languages.registerCompletionItemProvider(documentSelector, new HLSLCompletionItemProvider(), '.'));
+    context.subscriptions.push(vscode.languages.registerSignatureHelpProvider(documentSelector, new HLSLSignatureHelpProvider(), '(', ','));
+    context.subscriptions.push(vscode.languages.registerReferenceProvider(documentSelector, new HLSLReferenceProvider()));
 
     let symbolProvider = new HLSLSymbolProvider();
-    context.subscriptions.push(vscode.languages.registerDocumentSymbolProvider('hlsl', symbolProvider));
-    context.subscriptions.push(vscode.languages.registerWorkspaceSymbolProvider(symbolProvider));
+    context.subscriptions.push(vscode.languages.registerDocumentSymbolProvider(documentSelector, symbolProvider));
+
+    if (vscode.workspace.rootPath) {
+        context.subscriptions.push(vscode.languages.registerWorkspaceSymbolProvider(symbolProvider));
+    }
 
     let definitionProvider = new HLSLDefinitionProvider();
-    context.subscriptions.push(vscode.languages.registerDefinitionProvider('hlsl', definitionProvider));
-    context.subscriptions.push(vscode.languages.registerImplementationProvider('hlsl', definitionProvider));
-    context.subscriptions.push(vscode.languages.registerTypeDefinitionProvider('hlsl', definitionProvider));
+    context.subscriptions.push(vscode.languages.registerDefinitionProvider(documentSelector, definitionProvider));
+    context.subscriptions.push(vscode.languages.registerImplementationProvider(documentSelector, definitionProvider));
+    context.subscriptions.push(vscode.languages.registerTypeDefinitionProvider(documentSelector, definitionProvider));
 
     if (vscode.extensions.getExtension('ms-vscode.cpptools') !== undefined) {
         let formatingProvider = new HLSLFormatingProvider();
-        context.subscriptions.push(vscode.languages.registerDocumentFormattingEditProvider('hlsl', formatingProvider));
-        context.subscriptions.push(vscode.languages.registerDocumentRangeFormattingEditProvider('hlsl', formatingProvider));
+        context.subscriptions.push(vscode.languages.registerDocumentFormattingEditProvider(documentSelector, formatingProvider));
+        context.subscriptions.push(vscode.languages.registerDocumentRangeFormattingEditProvider(documentSelector, formatingProvider));
     }
 
 }


### PR DESCRIPTION
In preparation for [Visual Studio Live Share](https://aka.ms/vsls) adding support for "guests" to receive remote language services for HLSL, this PR simply updates the current `DocumentSelector` to be limited to `file` and `untitled` (unsaved) files. This way, when someone has this extension installed, and joins a Live Share session (where files use the `vsls:` scheme), their language services will be entirely derived from the remote/host side, which provides a more accurate and project-wide experience (guests in Live Share don't have local file access to the project they're collaborating with).

*Note: As an example, the TypeScript/JavaScript language services that come in-box with VS Code [already have this scheme restriction](https://github.com/Microsoft/vscode/blob/master/extensions/typescript-language-features/src/utils/fileSchemes.ts#L12), and so this PR replicates that behavior.*