### PR TITLE
Highlighting GLSL, HLSL and Cg shaders inside C++11 raw strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,36 @@
 				"embeddedLanguages": {
 					"source.glsl": "glsl"
 				}
+			},
+			{
+				"scopeName": "source.cpp.glsl",
+				"path": "./syntaxes/glsl-cpp.tmLanguage.json",
+				"injectTo": [
+					"source.cpp"
+				],
+				"embeddedLanguages": {
+					"source.glsl": "glsl"
+				}
+			},
+			{
+				"scopeName": "source.cpp.hlsl",
+				"path": "./syntaxes/hlsl-cpp.tmLanguage.json",
+				"injectTo": [
+					"source.cpp"
+				],
+				"embeddedLanguages": {
+					"source.hlsl": "hlsl"
+				}
+			},
+			{
+				"scopeName": "source.cpp.cg",
+				"path": "./syntaxes/cg-cpp.tmLanguage.json",
+				"injectTo": [
+					"source.cpp"
+				],
+				"embeddedLanguages": {
+					"source.cg": "cg"
+				}
 			}
 		],
 		"configuration": {

--- a/syntaxes/cg-cpp.tmLanguage.json
+++ b/syntaxes/cg-cpp.tmLanguage.json
@@ -1,0 +1,44 @@
+{
+    "scopeName": "source.cpp.cg",
+    "injectionSelector": "L:source.cpp",
+    "patterns": [
+        {
+            "include": "#cg-raw-string"
+        }
+    ],
+    "repository": {
+        "cg-raw-string": {
+            "begin": "R\"(?i:cg)(\\()",
+            "beginCaptures": {
+                "0": {
+                    "name": "punctuation.definition.string.begin.cpp"
+                },
+                "1": {
+                    "name": "cg.delimeter.raw.string.cpp"
+                }
+            },
+            "end": "\\)(?i:cg)\"",
+            "endCaptures": {
+                "0": {
+                    "name": "punctuation.definition.string.end.cpp"
+                },
+                "1": {
+                    "name": "cg.delimeter.raw.string.cpp"
+                }
+            },
+            "name": "cg.raw.string.cpp",
+            "patterns": [
+                {
+                    "contentName": "source.cg",
+                    "begin": "(?!\\G)",
+                    "end": "(?i)(?=\\)cg\")",
+                    "patterns": [
+                        {
+                            "include": "source.cg"
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/syntaxes/glsl-cpp.tmLanguage.json
+++ b/syntaxes/glsl-cpp.tmLanguage.json
@@ -1,0 +1,44 @@
+{
+    "scopeName": "source.cpp.glsl",
+    "injectionSelector": "L:source.cpp",
+    "patterns": [
+        {
+            "include": "#glsl-raw-string"
+        }
+    ],
+    "repository": {
+        "glsl-raw-string": {
+            "begin": "R\"(?i:glsl)(\\()",
+            "beginCaptures": {
+                "0": {
+                    "name": "punctuation.definition.string.begin.cpp"
+                },
+                "1": {
+                    "name": "glsl.delimeter.raw.string.cpp"
+                }
+            },
+            "end": "\\)(?i:glsl)\"",
+            "endCaptures": {
+                "0": {
+                    "name": "punctuation.definition.string.end.cpp"
+                },
+                "1": {
+                    "name": "glsl.delimeter.raw.string.cpp"
+                }
+            },
+            "name": "glsl.raw.string.cpp",
+            "patterns": [
+                {
+                    "contentName": "source.glsl",
+                    "begin": "(?!\\G)",
+                    "end": "(?i)(?=\\)glsl\")",
+                    "patterns": [
+                        {
+                            "include": "source.glsl"
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/syntaxes/glsl-html.tmLanguage.json
+++ b/syntaxes/glsl-html.tmLanguage.json
@@ -86,7 +86,7 @@
             ]
         },
         "glsl-tag": {
-            "begin": "(<)((?i:glsl))",
+            "begin": "(?i)(?=<glsl\\s+.*?(?:\\s+|>))(<)(glsl)",
             "beginCaptures": {
                 "1": {
                     "name": "punctuation.definition.tag.begin.html"
@@ -110,16 +110,26 @@
                     "name": "punctuation.definition.tag.end.html"
                 }
             },
+            "name": "meta.tag.glsl.html",
             "patterns": [
                 {
-                    "contentName": "source.glsl.embedded.html",
-                    "begin": "(>)",
-                    "beginCaptures": {
+                    "begin": "\\G",
+                    "end": "(>)",
+                    "endCaptures": {
                         "1": {
                             "name": "punctuation.definition.tag.end.html"
                         }
                     },
-                    "end": "(?=</glsl>)",
+                    "patterns": [
+                        {
+                            "include": "#tag-stuff"
+                        }
+                    ]
+                },
+                {
+                    "contentName": "source.glsl",
+                    "begin": "(?!\\G)",
+                    "end": "(?i)(?=</glsl>)",
                     "patterns": [
                         {
                             "include": "source.glsl"

--- a/syntaxes/hlsl-cpp.tmLanguage.json
+++ b/syntaxes/hlsl-cpp.tmLanguage.json
@@ -1,0 +1,44 @@
+{
+    "scopeName": "source.cpp.hlsl",
+    "injectionSelector": "L:source.cpp",
+    "patterns": [
+        {
+            "include": "#hlsl-raw-string"
+        }
+    ],
+    "repository": {
+        "hlsl-raw-string": {
+            "begin": "R\"(?i:hlsl)(\\()",
+            "beginCaptures": {
+                "0": {
+                    "name": "punctuation.definition.string.begin.cpp"
+                },
+                "1": {
+                    "name": "hlsl.delimeter.raw.string.cpp"
+                }
+            },
+            "end": "\\)(?i:hlsl)\"",
+            "endCaptures": {
+                "0": {
+                    "name": "punctuation.definition.string.end.cpp"
+                },
+                "1": {
+                    "name": "hlsl.delimeter.raw.string.cpp"
+                }
+            },
+            "name": "hlsl.raw.string.cpp",
+            "patterns": [
+                {
+                    "contentName": "source.hlsl",
+                    "begin": "(?!\\G)",
+                    "end": "(?i)(?=\\)hlsl\")",
+                    "patterns": [
+                        {
+                            "include": "source.hlsl"
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
Highlighting GLSL, HLSL and Cg shaders inside C++11 raw strings
fixes #13

example of highlighting GLSL shader inside C++11 raw string using `glsl` delimiter:
```c++
const char vertex_shader[] = R"glsl(
    #version 330 core
    attribute vec2 vPos;

    void main() {
        gl_Position = vec4(vPos, 0., 1.);
    }
)glsl";
```

fixed highlighting of `<glsl>` tag attributes inside HTML