### PR TITLE
inject glsl,hlsl,cg to markdown fenced code block

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,6 +137,16 @@
 				"embeddedLanguages": {
 					"source.cg": "cg"
 				}
+			},
+			{
+				"scopeName": "markdown.shader.codeblock",
+				"path": "./syntaxes/markdown-codeblock.json",
+				"injectTo": [
+				  "text.html.markdown"
+				],
+				"embeddedLanguages": {
+				  "meta.embedded.block.shader": "glsl"
+				}
 			}
 		],
 		"configuration": {

--- a/package.json
+++ b/package.json
@@ -139,13 +139,16 @@
 				}
 			},
 			{
-				"scopeName": "markdown.shader.codeblock",
+				"scopeName": "markdown.fenced.codeblock",
 				"path": "./syntaxes/markdown-codeblock.json",
 				"injectTo": [
 				  "text.html.markdown"
 				],
 				"embeddedLanguages": {
-				  "meta.embedded.block.shader": "glsl"
+				  "meta.embedded.block.glsl": "glsl",
+				  "meta.embedded.block.hlsl": "hlsl",
+				  "meta.embedded.block.cg": "cg",
+				  "meta.embedded.block.shaderlab": "shaderlab"
 				}
 			}
 		],

--- a/syntaxes/markdown-codeblock.json
+++ b/syntaxes/markdown-codeblock.json
@@ -1,7 +1,7 @@
 {
 	"fileTypes": [],
 	"injectionSelector": "L:text.html.markdown",
-	"scopeName": "markdown.shader.codeblock",
+	"scopeName": "markdown.fenced.codeblock",
 	"patterns": [
 		{
 			"include": "#fenced-code-block"
@@ -11,12 +11,21 @@
 		"fenced-code-block" : {
 			"patterns":[
 				{
-					"include": "#fenced-code-block-shader"
+					"include": "#fenced-code-block-glsl"
+				},
+                {
+					"include": "#fenced-code-block-hlsl"
+				},
+                {
+					"include": "#fenced-code-block-cg"
+				},
+                {
+					"include": "#fenced-code-block-shaderlab"
 				}
 			]
 		},
-		"fenced-code-block-shader": {
-			"begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(shader)(\\s+[^`~]*)?$)",
+		"fenced-code-block-glsl": {
+			"begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(glsl)(\\s+[^`~]*)?$)",
 			"name": "markup.fenced_code.block.markdown",
 			"end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
 			"beginCaptures": {
@@ -39,10 +48,109 @@
 				{
 					"begin": "(^|\\G)(\\s*)(.*)",
 					"while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
-					"contentName": "meta.embedded.block.shader",
+					"contentName": "meta.embedded.block.glsl",
 					"patterns": [
 						{
 							"include": "source.glsl"
+						}
+					]
+				}
+			]
+		},
+        "fenced-code-block-hlsl": {
+			"begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(hlsl)(\\s+[^`~]*)?$)",
+			"name": "markup.fenced_code.block.markdown",
+			"end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+			"beginCaptures": {
+				"3": {
+					"name": "punctuation.definition.markdown"
+				},
+				"4": {
+					"name": "fenced_code.block.language.markdown"
+				},
+				"5": {
+					"name": "fenced_code.block.language.attributes.markdown"
+				}
+			},
+			"endCaptures": {
+				"3": {
+					"name": "punctuation.definition.markdown"
+				}
+			},
+			"patterns": [
+				{
+					"begin": "(^|\\G)(\\s*)(.*)",
+					"while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+					"contentName": "meta.embedded.block.hlsl",
+					"patterns": [
+						{
+							"include": "source.hlsl"
+						}
+					]
+				}
+			]
+		},
+        "fenced-code-block-cg": {
+			"begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(cg)(\\s+[^`~]*)?$)",
+			"name": "markup.fenced_code.block.markdown",
+			"end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+			"beginCaptures": {
+				"3": {
+					"name": "punctuation.definition.markdown"
+				},
+				"4": {
+					"name": "fenced_code.block.language.markdown"
+				},
+				"5": {
+					"name": "fenced_code.block.language.attributes.markdown"
+				}
+			},
+			"endCaptures": {
+				"3": {
+					"name": "punctuation.definition.markdown"
+				}
+			},
+			"patterns": [
+				{
+					"begin": "(^|\\G)(\\s*)(.*)",
+					"while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+					"contentName": "meta.embedded.block.cg",
+					"patterns": [
+						{
+							"include": "source.cg"
+						}
+					]
+				}
+			]
+		},
+        "fenced-code-block-shaderlab": {
+			"begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(shaderlab)(\\s+[^`~]*)?$)",
+			"name": "markup.fenced_code.block.markdown",
+			"end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+			"beginCaptures": {
+				"3": {
+					"name": "punctuation.definition.markdown"
+				},
+				"4": {
+					"name": "fenced_code.block.language.markdown"
+				},
+				"5": {
+					"name": "fenced_code.block.language.attributes.markdown"
+				}
+			},
+			"endCaptures": {
+				"3": {
+					"name": "punctuation.definition.markdown"
+				}
+			},
+			"patterns": [
+				{
+					"begin": "(^|\\G)(\\s*)(.*)",
+					"while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+					"contentName": "meta.embedded.block.shaderlab",
+					"patterns": [
+						{
+							"include": "source.shaderlab"
 						}
 					]
 				}

--- a/syntaxes/markdown-codeblock.json
+++ b/syntaxes/markdown-codeblock.json
@@ -1,0 +1,52 @@
+{
+	"fileTypes": [],
+	"injectionSelector": "L:text.html.markdown",
+	"scopeName": "markdown.shader.codeblock",
+	"patterns": [
+		{
+			"include": "#fenced-code-block"
+		}
+	],
+	"repository": {
+		"fenced-code-block" : {
+			"patterns":[
+				{
+					"include": "#fenced-code-block-shader"
+				}
+			]
+		},
+		"fenced-code-block-shader": {
+			"begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(shader)(\\s+[^`~]*)?$)",
+			"name": "markup.fenced_code.block.markdown",
+			"end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+			"beginCaptures": {
+				"3": {
+					"name": "punctuation.definition.markdown"
+				},
+				"4": {
+					"name": "fenced_code.block.language.markdown"
+				},
+				"5": {
+					"name": "fenced_code.block.language.attributes.markdown"
+				}
+			},
+			"endCaptures": {
+				"3": {
+					"name": "punctuation.definition.markdown"
+				}
+			},
+			"patterns": [
+				{
+					"begin": "(^|\\G)(\\s*)(.*)",
+					"while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+					"contentName": "meta.embedded.block.shader",
+					"patterns": [
+						{
+							"include": "source.glsl"
+						}
+					]
+				}
+			]
+		}
+	}
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4133961/125631177-287bacec-835a-41a5-b57e-1a499b68bd10.png)

#34 get GLSL syntax highlighting working in markdown
