### PR TITLE
Add more file extensions or Configurable file extensions?

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
 					".glsl",
 					".glslv",
 					".glslf",
-					".glslg"
+					".glslg",
+					".es"
 				],
 				"configuration": "./glsl.configuration.json"
 			},


### PR DESCRIPTION
I am wondering if the file extensions for shading language can be configurable(either add a configure file or add a new command option).
Shadeing Language files are plain text files and may have any extension names, so I think this will help those who write shader files with extensions not in the current extension lists.

As for this pr, I only add an extension to the package.json(forgive me, I am not familiar with typescript).