### PR TITLE
Fix searchRGPath to fix warning 'vscode-shader couldn't find vscode-ripgrep binary path'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,348 +1,458 @@
 {
 	"name": "shader",
 	"version": "1.1.5",
-	"lockfileVersion": 1,
+	"lockfileVersion": 3,
 	"requires": true,
-	"dependencies": {
-		"@types/node": {
+	"packages": {
+		"": {
+			"name": "shader",
+			"version": "1.1.5",
+			"license": "LICENSE.md",
+			"dependencies": {
+				"follow-redirects": "^1.5.8",
+				"jsdom": "^11.3.0",
+				"tmp": "0.0.33"
+			},
+			"devDependencies": {
+				"@types/node": "^12.18.3",
+				"@types/tmp": "^0.2.0",
+				"@types/vscode": "^1.53",
+				"typescript": "^4.1.3"
+			},
+			"engines": {
+				"vscode": "^1.53.0"
+			}
+		},
+		"node_modules/@types/node": {
 			"version": "12.19.16",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.16.tgz",
 			"integrity": "sha512-7xHmXm/QJ7cbK2laF+YYD7gb5MggHIIQwqyjin3bpEGiSuvScMQ5JZZXPvRipi1MwckTQbJZROMns/JxdnIL1Q==",
 			"dev": true
 		},
-		"@types/tmp": {
+		"node_modules/@types/tmp": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.0.tgz",
 			"integrity": "sha512-flgpHJjntpBAdJD43ShRosQvNC0ME97DCfGvZEDlAThQmnerRXrLbX6YgzRBQCZTthET9eAWFAMaYP0m0Y4HzQ==",
 			"dev": true
 		},
-		"@types/vscode": {
+		"node_modules/@types/vscode": {
 			"version": "1.53.0",
 			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.53.0.tgz",
 			"integrity": "sha512-XjFWbSPOM0EKIT2XhhYm3D3cx3nn3lshMUcWNy1eqefk+oqRuBq8unVb6BYIZqXy9lQZyeUl7eaBCOZWv+LcXQ==",
 			"dev": true
 		},
-		"abab": {
+		"node_modules/abab": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
-			"integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q=="
+			"integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
+			"deprecated": "Use your platform's native atob() and btoa() methods instead"
 		},
-		"acorn": {
+		"node_modules/acorn": {
 			"version": "5.7.4",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
-			"integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg=="
+			"integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
+			"bin": {
+				"acorn": "bin/acorn"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
 		},
-		"acorn-globals": {
+		"node_modules/acorn-globals": {
 			"version": "4.3.4",
 			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.4.tgz",
 			"integrity": "sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==",
-			"requires": {
+			"dependencies": {
 				"acorn": "^6.0.1",
 				"acorn-walk": "^6.0.1"
-			},
-			"dependencies": {
-				"acorn": {
-					"version": "6.4.2",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
-					"integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ=="
-				}
 			}
 		},
-		"acorn-walk": {
+		"node_modules/acorn-globals/node_modules/acorn": {
+			"version": "6.4.2",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
+			"integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
+			"bin": {
+				"acorn": "bin/acorn"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/acorn-walk": {
 			"version": "6.2.0",
 			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
-			"integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA=="
+			"integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==",
+			"engines": {
+				"node": ">=0.4.0"
+			}
 		},
-		"ajv": {
+		"node_modules/ajv": {
 			"version": "6.12.6",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-			"requires": {
+			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
 				"json-schema-traverse": "^0.4.1",
 				"uri-js": "^4.2.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
 			}
 		},
-		"array-equal": {
+		"node_modules/array-equal": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
 			"integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
 		},
-		"asn1": {
+		"node_modules/asn1": {
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
 			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-			"requires": {
+			"dependencies": {
 				"safer-buffer": "~2.1.0"
 			}
 		},
-		"assert-plus": {
+		"node_modules/assert-plus": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+			"engines": {
+				"node": ">=0.8"
+			}
 		},
-		"async-limiter": {
+		"node_modules/async-limiter": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
 			"integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
 		},
-		"asynckit": {
+		"node_modules/asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
 			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
 		},
-		"aws-sign2": {
+		"node_modules/aws-sign2": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+			"engines": {
+				"node": "*"
+			}
 		},
-		"aws4": {
+		"node_modules/aws4": {
 			"version": "1.11.0",
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
 			"integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
 		},
-		"bcrypt-pbkdf": {
+		"node_modules/bcrypt-pbkdf": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
 			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-			"requires": {
+			"dependencies": {
 				"tweetnacl": "^0.14.3"
 			}
 		},
-		"browser-process-hrtime": {
+		"node_modules/browser-process-hrtime": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
 			"integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow=="
 		},
-		"caseless": {
+		"node_modules/caseless": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
 			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
 		},
-		"combined-stream": {
+		"node_modules/combined-stream": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
 			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-			"requires": {
+			"dependencies": {
 				"delayed-stream": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8"
 			}
 		},
-		"core-util-is": {
+		"node_modules/core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
 		},
-		"cssom": {
+		"node_modules/cssom": {
 			"version": "0.3.8",
 			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
 			"integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
 		},
-		"cssstyle": {
+		"node_modules/cssstyle": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.4.0.tgz",
 			"integrity": "sha512-GBrLZYZ4X4x6/QEoBnIrqb8B/f5l4+8me2dkom/j1Gtbxy0kBv6OGzKuAsGM75bkGwGAFkt56Iwg28S3XTZgSA==",
-			"requires": {
+			"dependencies": {
 				"cssom": "0.3.x"
 			}
 		},
-		"dashdash": {
+		"node_modules/dashdash": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-			"requires": {
+			"dependencies": {
 				"assert-plus": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10"
 			}
 		},
-		"data-urls": {
+		"node_modules/data-urls": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
 			"integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
-			"requires": {
+			"dependencies": {
 				"abab": "^2.0.0",
 				"whatwg-mimetype": "^2.2.0",
 				"whatwg-url": "^7.0.0"
-			},
-			"dependencies": {
-				"whatwg-url": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
-					"integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
-					"requires": {
-						"lodash.sortby": "^4.7.0",
-						"tr46": "^1.0.1",
-						"webidl-conversions": "^4.0.2"
-					}
-				}
 			}
 		},
-		"deep-is": {
+		"node_modules/data-urls/node_modules/whatwg-url": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+			"integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+			"dependencies": {
+				"lodash.sortby": "^4.7.0",
+				"tr46": "^1.0.1",
+				"webidl-conversions": "^4.0.2"
+			}
+		},
+		"node_modules/deep-is": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
 			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
 		},
-		"delayed-stream": {
+		"node_modules/delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+			"engines": {
+				"node": ">=0.4.0"
+			}
 		},
-		"domexception": {
+		"node_modules/domexception": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
 			"integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
-			"requires": {
+			"deprecated": "Use your platform's native DOMException instead",
+			"dependencies": {
 				"webidl-conversions": "^4.0.2"
 			}
 		},
-		"ecc-jsbn": {
+		"node_modules/ecc-jsbn": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
 			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-			"requires": {
+			"dependencies": {
 				"jsbn": "~0.1.0",
 				"safer-buffer": "^2.1.0"
 			}
 		},
-		"escodegen": {
+		"node_modules/escodegen": {
 			"version": "1.14.3",
 			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
 			"integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
-			"requires": {
+			"dependencies": {
 				"esprima": "^4.0.1",
 				"estraverse": "^4.2.0",
 				"esutils": "^2.0.2",
-				"optionator": "^0.8.1",
+				"optionator": "^0.8.1"
+			},
+			"bin": {
+				"escodegen": "bin/escodegen.js",
+				"esgenerate": "bin/esgenerate.js"
+			},
+			"engines": {
+				"node": ">=4.0"
+			},
+			"optionalDependencies": {
 				"source-map": "~0.6.1"
 			}
 		},
-		"esprima": {
+		"node_modules/esprima": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"bin": {
+				"esparse": "bin/esparse.js",
+				"esvalidate": "bin/esvalidate.js"
+			},
+			"engines": {
+				"node": ">=4"
+			}
 		},
-		"estraverse": {
+		"node_modules/estraverse": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
+			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+			"engines": {
+				"node": ">=4.0"
+			}
 		},
-		"esutils": {
+		"node_modules/esutils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
+			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
-		"extend": {
+		"node_modules/extend": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
 			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
 		},
-		"extsprintf": {
+		"node_modules/extsprintf": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+			"engines": [
+				"node >=0.6.0"
+			]
 		},
-		"fast-deep-equal": {
+		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
 		},
-		"fast-json-stable-stringify": {
+		"node_modules/fast-json-stable-stringify": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
 			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
 		},
-		"fast-levenshtein": {
+		"node_modules/fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
 		},
-		"follow-redirects": {
+		"node_modules/follow-redirects": {
 			"version": "1.13.2",
 			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.2.tgz",
-			"integrity": "sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA=="
+			"integrity": "sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://github.com/sponsors/RubenVerborgh"
+				}
+			],
+			"engines": {
+				"node": ">=4.0"
+			},
+			"peerDependenciesMeta": {
+				"debug": {
+					"optional": true
+				}
+			}
 		},
-		"forever-agent": {
+		"node_modules/forever-agent": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+			"engines": {
+				"node": "*"
+			}
 		},
-		"form-data": {
+		"node_modules/form-data": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
 			"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-			"requires": {
+			"dependencies": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.6",
 				"mime-types": "^2.1.12"
+			},
+			"engines": {
+				"node": ">= 0.12"
 			}
 		},
-		"getpass": {
+		"node_modules/getpass": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-			"requires": {
+			"dependencies": {
 				"assert-plus": "^1.0.0"
 			}
 		},
-		"har-schema": {
+		"node_modules/har-schema": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+			"engines": {
+				"node": ">=4"
+			}
 		},
-		"har-validator": {
+		"node_modules/har-validator": {
 			"version": "5.1.5",
 			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
 			"integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-			"requires": {
+			"deprecated": "this library is no longer supported",
+			"dependencies": {
 				"ajv": "^6.12.3",
 				"har-schema": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=6"
 			}
 		},
-		"html-encoding-sniffer": {
+		"node_modules/html-encoding-sniffer": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
 			"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
-			"requires": {
+			"dependencies": {
 				"whatwg-encoding": "^1.0.1"
 			}
 		},
-		"http-signature": {
+		"node_modules/http-signature": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-			"requires": {
+			"dependencies": {
 				"assert-plus": "^1.0.0",
 				"jsprim": "^1.2.2",
 				"sshpk": "^1.7.0"
+			},
+			"engines": {
+				"node": ">=0.8",
+				"npm": ">=1.3.7"
 			}
 		},
-		"iconv-lite": {
+		"node_modules/iconv-lite": {
 			"version": "0.4.24",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
 			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-			"requires": {
+			"dependencies": {
 				"safer-buffer": ">= 2.1.2 < 3"
+			},
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
-		"is-typedarray": {
+		"node_modules/is-typedarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
 			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
 		},
-		"isstream": {
+		"node_modules/isstream": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
 			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
 		},
-		"jsbn": {
+		"node_modules/jsbn": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
 			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
 		},
-		"jsdom": {
+		"node_modules/jsdom": {
 			"version": "11.12.0",
 			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.12.0.tgz",
 			"integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
-			"requires": {
+			"dependencies": {
 				"abab": "^2.0.0",
 				"acorn": "^5.5.3",
 				"acorn-globals": "^4.1.0",
@@ -371,137 +481,169 @@
 				"xml-name-validator": "^3.0.0"
 			}
 		},
-		"json-schema": {
+		"node_modules/json-schema": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
 			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
 		},
-		"json-schema-traverse": {
+		"node_modules/json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
 			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
 		},
-		"json-stringify-safe": {
+		"node_modules/json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
 			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
 		},
-		"jsprim": {
+		"node_modules/jsprim": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
 			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-			"requires": {
+			"engines": [
+				"node >=0.6.0"
+			],
+			"dependencies": {
 				"assert-plus": "1.0.0",
 				"extsprintf": "1.3.0",
 				"json-schema": "0.2.3",
 				"verror": "1.10.0"
 			}
 		},
-		"left-pad": {
+		"node_modules/left-pad": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
-			"integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA=="
+			"integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
+			"deprecated": "use String.prototype.padStart()"
 		},
-		"levn": {
+		"node_modules/levn": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
 			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-			"requires": {
+			"dependencies": {
 				"prelude-ls": "~1.1.2",
 				"type-check": "~0.3.2"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
 			}
 		},
-		"lodash": {
+		"node_modules/lodash": {
 			"version": "4.17.20",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
 			"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
 		},
-		"lodash.sortby": {
+		"node_modules/lodash.sortby": {
 			"version": "4.7.0",
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
 			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
 		},
-		"mime-db": {
+		"node_modules/mime-db": {
 			"version": "1.45.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.45.0.tgz",
-			"integrity": "sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w=="
+			"integrity": "sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w==",
+			"engines": {
+				"node": ">= 0.6"
+			}
 		},
-		"mime-types": {
+		"node_modules/mime-types": {
 			"version": "2.1.28",
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.28.tgz",
 			"integrity": "sha512-0TO2yJ5YHYr7M2zzT7gDU1tbwHxEUWBCLt0lscSNpcdAfFyJOVEpRYNS7EXVcTLNj/25QO8gulHC5JtTzSE2UQ==",
-			"requires": {
+			"dependencies": {
 				"mime-db": "1.45.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
 			}
 		},
-		"nwsapi": {
+		"node_modules/nwsapi": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
 			"integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ=="
 		},
-		"oauth-sign": {
+		"node_modules/oauth-sign": {
 			"version": "0.9.0",
 			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+			"engines": {
+				"node": "*"
+			}
 		},
-		"optionator": {
+		"node_modules/optionator": {
 			"version": "0.8.3",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
 			"integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-			"requires": {
+			"dependencies": {
 				"deep-is": "~0.1.3",
 				"fast-levenshtein": "~2.0.6",
 				"levn": "~0.3.0",
 				"prelude-ls": "~1.1.2",
 				"type-check": "~0.3.2",
 				"word-wrap": "~1.2.3"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
 			}
 		},
-		"os-tmpdir": {
+		"node_modules/os-tmpdir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
-		"parse5": {
+		"node_modules/parse5": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
 			"integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA=="
 		},
-		"performance-now": {
+		"node_modules/performance-now": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
 			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
 		},
-		"pn": {
+		"node_modules/pn": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
 			"integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA=="
 		},
-		"prelude-ls": {
+		"node_modules/prelude-ls": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+			"engines": {
+				"node": ">= 0.8.0"
+			}
 		},
-		"psl": {
+		"node_modules/psl": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
 			"integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
 		},
-		"punycode": {
+		"node_modules/punycode": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+			"engines": {
+				"node": ">=6"
+			}
 		},
-		"qs": {
+		"node_modules/qs": {
 			"version": "6.5.2",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+			"engines": {
+				"node": ">=0.6"
+			}
 		},
-		"request": {
+		"node_modules/request": {
 			"version": "2.88.2",
 			"resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
 			"integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-			"requires": {
+			"deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
+			"dependencies": {
 				"aws-sign2": "~0.7.0",
 				"aws4": "^1.8.0",
 				"caseless": "~0.12.0",
@@ -522,52 +664,85 @@
 				"tough-cookie": "~2.5.0",
 				"tunnel-agent": "^0.6.0",
 				"uuid": "^3.3.2"
+			},
+			"engines": {
+				"node": ">= 6"
 			}
 		},
-		"request-promise-core": {
+		"node_modules/request-promise-core": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
 			"integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
-			"requires": {
+			"dependencies": {
 				"lodash": "^4.17.19"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			},
+			"peerDependencies": {
+				"request": "^2.34"
 			}
 		},
-		"request-promise-native": {
+		"node_modules/request-promise-native": {
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
 			"integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
-			"requires": {
+			"deprecated": "request-promise-native has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142",
+			"dependencies": {
 				"request-promise-core": "1.1.4",
 				"stealthy-require": "^1.1.1",
 				"tough-cookie": "^2.3.3"
+			},
+			"engines": {
+				"node": ">=0.12.0"
+			},
+			"peerDependencies": {
+				"request": "^2.34"
 			}
 		},
-		"safe-buffer": {
+		"node_modules/safe-buffer": {
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			]
 		},
-		"safer-buffer": {
+		"node_modules/safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
 		},
-		"sax": {
+		"node_modules/sax": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
 			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
 		},
-		"source-map": {
+		"node_modules/source-map": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-			"optional": true
+			"optional": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
-		"sshpk": {
+		"node_modules/sshpk": {
 			"version": "1.16.1",
 			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
 			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-			"requires": {
+			"dependencies": {
 				"asn1": "~0.2.3",
 				"assert-plus": "^1.0.0",
 				"bcrypt-pbkdf": "^1.0.0",
@@ -577,143 +752,184 @@
 				"jsbn": "~0.1.0",
 				"safer-buffer": "^2.0.2",
 				"tweetnacl": "~0.14.0"
+			},
+			"bin": {
+				"sshpk-conv": "bin/sshpk-conv",
+				"sshpk-sign": "bin/sshpk-sign",
+				"sshpk-verify": "bin/sshpk-verify"
+			},
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
-		"stealthy-require": {
+		"node_modules/stealthy-require": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
-		"symbol-tree": {
+		"node_modules/symbol-tree": {
 			"version": "3.2.4",
 			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
 			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
 		},
-		"tmp": {
+		"node_modules/tmp": {
 			"version": "0.0.33",
 			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
 			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-			"requires": {
+			"dependencies": {
 				"os-tmpdir": "~1.0.2"
+			},
+			"engines": {
+				"node": ">=0.6.0"
 			}
 		},
-		"tough-cookie": {
+		"node_modules/tough-cookie": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
 			"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-			"requires": {
+			"dependencies": {
 				"psl": "^1.1.28",
 				"punycode": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=0.8"
 			}
 		},
-		"tr46": {
+		"node_modules/tr46": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
 			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
-			"requires": {
+			"dependencies": {
 				"punycode": "^2.1.0"
 			}
 		},
-		"tunnel-agent": {
+		"node_modules/tunnel-agent": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-			"requires": {
+			"dependencies": {
 				"safe-buffer": "^5.0.1"
+			},
+			"engines": {
+				"node": "*"
 			}
 		},
-		"tweetnacl": {
+		"node_modules/tweetnacl": {
 			"version": "0.14.5",
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
 			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
 		},
-		"type-check": {
+		"node_modules/type-check": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-			"requires": {
+			"dependencies": {
 				"prelude-ls": "~1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
 			}
 		},
-		"typescript": {
+		"node_modules/typescript": {
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
 			"integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
-			"dev": true
+			"dev": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=4.2.0"
+			}
 		},
-		"uri-js": {
+		"node_modules/uri-js": {
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
 			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-			"requires": {
+			"dependencies": {
 				"punycode": "^2.1.0"
 			}
 		},
-		"uuid": {
+		"node_modules/uuid": {
 			"version": "3.4.0",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+			"deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+			"bin": {
+				"uuid": "bin/uuid"
+			}
 		},
-		"verror": {
+		"node_modules/verror": {
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-			"requires": {
+			"engines": [
+				"node >=0.6.0"
+			],
+			"dependencies": {
 				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
 				"extsprintf": "^1.2.0"
 			}
 		},
-		"w3c-hr-time": {
+		"node_modules/w3c-hr-time": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
 			"integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
-			"requires": {
+			"deprecated": "Use your platform's native performance.now() and performance.timeOrigin.",
+			"dependencies": {
 				"browser-process-hrtime": "^1.0.0"
 			}
 		},
-		"webidl-conversions": {
+		"node_modules/webidl-conversions": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
 			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
 		},
-		"whatwg-encoding": {
+		"node_modules/whatwg-encoding": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
 			"integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
-			"requires": {
+			"dependencies": {
 				"iconv-lite": "0.4.24"
 			}
 		},
-		"whatwg-mimetype": {
+		"node_modules/whatwg-mimetype": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
 			"integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g=="
 		},
-		"whatwg-url": {
+		"node_modules/whatwg-url": {
 			"version": "6.5.0",
 			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
 			"integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
-			"requires": {
+			"dependencies": {
 				"lodash.sortby": "^4.7.0",
 				"tr46": "^1.0.1",
 				"webidl-conversions": "^4.0.2"
 			}
 		},
-		"word-wrap": {
+		"node_modules/word-wrap": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
+			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+			"engines": {
+				"node": ">=0.10.0"
+			}
 		},
-		"ws": {
+		"node_modules/ws": {
 			"version": "5.2.2",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
 			"integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
-			"requires": {
+			"dependencies": {
 				"async-limiter": "~1.0.0"
 			}
 		},
-		"xml-name-validator": {
+		"node_modules/xml-name-validator": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
 			"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -53,31 +53,27 @@ function searchRgPath()
         return fs.existsSync( rgExePath ) ? rgExePath : undefined;
     }
 
-    let rgPath = "";
+    const pathsToTest = [
+        "node_modules",
+        "node_modules.asar.unpacked",   // If vscode-ripgrep is in an .asar file, then the binary is unpacked.
+    ];
 
-    rgPath = exePathIsDefined( Path.join( vscode.env.appRoot, "node_modules/vscode-ripgrep/bin/", exeName() ) );
-    if( rgPath ) {
-        return rgPath;
+    // See https://github.com/stef-levesque/vscode-shader/issues/56
+    const extNamesToTest = [
+        "vscode-ripgrep",       // old extension name
+        "@vscode/ripgrep",      // new extension name
+    ];
+
+    for (const path of pathsToTest) {
+        for (const ext of extNamesToTest) {
+            let rgPath = exePathIsDefined( Path.join( vscode.env.appRoot, `${path}/${ext}/bin/`, exeName() ) );
+            if( rgPath ) {
+                return rgPath;
+            }
+        }
     }
 
-
-    rgPath = exePathIsDefined( Path.join( vscode.env.appRoot, "node_modules/@vscode/ripgrep/bin/", exeName() ) );
-    if( rgPath ) {
-        return rgPath;
-    }
-
-    // If vscode-ripgrep is in an .asar file, then the binary is unpacked.
-    rgPath = exePathIsDefined( Path.join( vscode.env.appRoot, "node_modules.asar.unpacked/vscode-ripgrep/bin/", exeName() ) );
-    if( rgPath ) {
-        return rgPath;
-    }
-
-    rgPath = exePathIsDefined( Path.join( vscode.env.appRoot, "node_modules.asar.unpacked/@vscode/ripgrep/bin/", exeName() ) );
-    if( rgPath ) {
-        return rgPath;
-    }
-
-    return rgPath;
+    return undefined;
 }
 
 export async function activate(context: vscode.ExtensionContext) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -60,8 +60,19 @@ function searchRgPath()
         return rgPath;
     }
 
+
+    rgPath = exePathIsDefined( Path.join( vscode.env.appRoot, "node_modules/@vscode/ripgrep/bin/", exeName() ) );
+    if( rgPath ) {
+        return rgPath;
+    }
+
     // If vscode-ripgrep is in an .asar file, then the binary is unpacked.
     rgPath = exePathIsDefined( Path.join( vscode.env.appRoot, "node_modules.asar.unpacked/vscode-ripgrep/bin/", exeName() ) );
+    if( rgPath ) {
+        return rgPath;
+    }
+
+    rgPath = exePathIsDefined( Path.join( vscode.env.appRoot, "node_modules.asar.unpacked/@vscode/ripgrep/bin/", exeName() ) );
     if( rgPath ) {
         return rgPath;
     }


### PR DESCRIPTION
Hello,

This fixes #56. I just added fallbacks for if we didn't find it in the old paths. (minor: I can swap old and new if you prefer)

Not sure if package-lock.json needs to be submitted, afaik it was auto updated by npm.